### PR TITLE
Support python26 by not using check_output

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -36,9 +36,14 @@ def _initialize_logger(level=logging.DEBUG, logfile=None):
 
 
 def _check_ansible_version():
-    version_output = subprocess.check_output(
-        ["ansible-playbook --version"], shell=True)
-    version_output = version_output.split('\n')[0]
+    process = subprocess.Popen(
+        ["ansible-playbook --version"], shell=True,
+        stdout=subprocess.PIPE)
+    output, _ = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        raise Exception("Error discovering ansible version")
+    version_output = output.split('\n')[0]
     version = version_output.split(' ')[1]
     if not version == ANSIBLE_VERSION:
         raise Exception("You are not using ansible-playbook '%s'. "


### PR DESCRIPTION
This is lame, revert when all our old systems are ashes.
