### PR TITLE
Enable verbose ansible when debug is enabled

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -122,6 +122,9 @@ def run(args, extra_args):
     if args.ursula_test:
         extra_args += ['--syntax-check', '--list-tasks']
 
+    if args.usrula_debug:
+        extra_args += ['-vvvv']
+
     rc = _run_ansible(inventory, args.playbook, extra_args=extra_args)
     return rc
 


### PR DESCRIPTION
If were running with debug we probably also want to know what ansible is
up to.
