### PR TITLE
Set python encoding

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -61,6 +61,7 @@ def _append_envvar(key, value):
 
 def _set_default_env():
     _append_envvar('PYTHONUNBUFFERED', '1')  # needed in order to stream output
+    _append_envvar('PYTHONIOENCODING', 'UTF-8')  # needed to handle stdin input
     _append_envvar('ANSIBLE_FORCE_COLOR', 'yes')
     _append_envvar('ANSIBLE_SSH_ARGS', '-o ControlMaster=auto')
     _append_envvar("ANSIBLE_SSH_ARGS",


### PR DESCRIPTION
Ansible was finding sys.stdin.encoding to be None and not handling that
well, which we can work around by setting the python encoding to be
UTF-8, which subprocess will pick up. This /may/ break terminals that
don't support UTF-8, but really....
