### PR TITLE
Create controlmasters directory if missing

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -65,6 +65,9 @@ def _set_envvar(key, value):
 
 
 def _set_default_env():
+    if not os.path.exists('~/.ssh/controlmasters'):
+        os.makedirs('~/.ssh/controlmasters')
+
     _append_envvar('PYTHONUNBUFFERED', '1')  # needed in order to stream output
     _append_envvar('PYTHONIOENCODING', 'UTF-8')  # needed to handle stdin input
     _append_envvar('ANSIBLE_FORCE_COLOR', 'yes')


### PR DESCRIPTION
If we are using the controllmasters directory, create it if it doesn't
already exist.
