### PR TITLE
Set environment variables instead of appending

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -68,9 +68,9 @@ def _set_default_env():
     if not os.path.exists('~/.ssh/controlmasters'):
         os.makedirs('~/.ssh/controlmasters')
 
-    _append_envvar('PYTHONUNBUFFERED', '1')  # needed in order to stream output
-    _append_envvar('PYTHONIOENCODING', 'UTF-8')  # needed to handle stdin input
-    _append_envvar('ANSIBLE_FORCE_COLOR', 'yes')
+    _set_envvar('PYTHONUNBUFFERED', '1')  # needed in order to stream output
+    _set_envvar('PYTHONIOENCODING', 'UTF-8')  # needed to handle stdin input
+    _set_envvar('ANSIBLE_FORCE_COLOR', 'yes')
     _append_envvar('ANSIBLE_SSH_ARGS', '-o ControlMaster=auto')
     _append_envvar("ANSIBLE_SSH_ARGS",
                    "-o ControlPath=~/.ssh/controlmasters/u-%r@%h:%p")


### PR DESCRIPTION
Unlike ANSIBLE_SSH_ARGS, many of the environment variables need to be
set versus appended. Make it so.
