### PR TITLE
fixed ansible version error wording

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -47,7 +47,7 @@ def _check_ansible_version():
     version_output = output.split('\n')[0]
     version = version_output.split(' ')[1]
     if not version == ANSIBLE_VERSION:
-        raise Exception("You are not using ansible-playbook '%s'. "
+        raise Exception("You are using ansible-playbook '%s'. "
                         "Current required version is: '%s'. You may install "
                         "the correct version with 'pip install -U -r "
                         "requirements.txt'" % (version, ANSIBLE_VERSION))


### PR DESCRIPTION
fixed exception string shown when using the wrong ansible version.  Changed "You are not using ansible-playbook ‘1.9.1’.” to "You are using ansible-playbook ‘1.9.1’."  (removed the word "not")
