### PR TITLE
Update our req for our 1.9 based ansible fork

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -23,7 +23,7 @@ import sys
 import yaml
 
 LOG = logging.getLogger(__name__)
-ANSIBLE_VERSION = '1.7.2-bbg'
+ANSIBLE_VERSION = '1.9.2-bbg'
 
 
 def _initialize_logger(level=logging.DEBUG, logfile=None):


### PR DESCRIPTION
A ursula-1.2.x branch was created that keeps the requirement on our ansible 1.7.2 fork.
