### PR TITLE
This fixes vagrant support.

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -18,6 +18,7 @@
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -142,6 +143,11 @@ def _vagrant_ssh_config(environment, boxes):
 
     return 0
 
+def _vagrant_copy_yml(environment):
+    src = "%s/vagrant.yml" % environment
+    dest = ".vagrant/vagrant.yml"
+    shutil.copy2(src, dest)
+
 def _run_vagrant(environment):
     vagrant_config_file = "%s/vagrant.yml" % environment
 
@@ -173,6 +179,7 @@ def _run_vagrant(environment):
                         % " ".join(command), os.environ)
         return proc.returncode
     else:
+
         print "**************************************************"
         print "Ursula <3 Vagrant"
         print "To interact with your environment via Vagrant set:"
@@ -219,7 +226,7 @@ def run(args, extra_args):
         rc = _run_vagrant(environment=args.environment)
         if rc:
             return rc
-
+        _vagrant_copy_yml(args.environment)
         rc = _run_ansible(inventory, args.playbook, extra_args=extra_args, user='vagrant', sudo=True)
         return rc
     else:

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -210,7 +210,10 @@ def run(args, extra_args):
     if os.path.isfile(ansible_var_defaults_file):
         _append_envvar("ANSIBLE_VAR_DEFAULTS_FILE", ansible_var_defaults_file)
 
-    ansible_ssh_config_file = os.path.join(args.environment, 'ssh_config')
+    if args.ursula_ssh_config:
+        ansible_ssh_config_file = args.ursula_ssh_config
+    else:
+        ansible_ssh_config_file = os.path.join(args.environment, 'ssh_config')
     if os.path.isfile(ansible_ssh_config_file):
         _append_envvar("ANSIBLE_SSH_ARGS", "-F %s" % ansible_ssh_config_file)
 
@@ -230,7 +233,7 @@ def run(args, extra_args):
         rc = _run_ansible(inventory, args.playbook, extra_args=extra_args, user='vagrant', sudo=True)
         return rc
     else:
-        rc = _run_ansible(inventory, args.playbook, extra_args=extra_args)
+        rc = _run_ansible(inventory, args.playbook, extra_args=extra_args, user=args.ursula_user, sudo=args.ursula_sudo)
         return rc
 
 
@@ -238,9 +241,10 @@ def main():
     parser = argparse.ArgumentParser(description='A CLI wrapper for ansible')
     parser.add_argument('environment', help='The environment you want to use')
     parser.add_argument('playbook', help='The playbook to run')
-
     # any args should be namespaced --ursula-$SOMETHING so as not to conflict
     # with ansible-playbook's command line parameters
+    parser.add_argument('--ursula-user', help='The user to run as', default='root')
+    parser.add_argument('--ursula-ssh-config', help='path to your ssh config')
     parser.add_argument('--ursula-forward', action='store_true',
                         help='The playbook to run')
     parser.add_argument('--ursula-test', action='store_true',
@@ -249,6 +253,8 @@ def main():
                         help='Run this tool in debug mode')
     parser.add_argument('--vagrant', action='store_true',
                         help='Provision environment in vagrant')
+    parser.add_argument('--ursula-sudo', action='store_true',
+                        help='Enable sudo')
 
     args, extra_args = parser.parse_known_args()
 


### PR DESCRIPTION
removes the need to run `bin/run_vagrant` in ursula repo.

```
$ ursula --vagrant envs/example/allinone site.yml
```
