### PR TITLE
Ensure the proper version of ansible is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+-e git://github.com/blueboxgroup/ansible.git@stable-1.9-bb#egg=ansible


### PR DESCRIPTION
Ansible version checking is built into ursula-cli, so let's make sure
the correct version is present by explicitly calling it out in the
requirements.txt file.
