### PR TITLE
Fix help string for '--ursula-forward'

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -416,7 +416,7 @@ def main():
         '--ursula-user', help='The user to run as', default=None)
     parser.add_argument('--ursula-ssh-config', help='path to your ssh config')
     parser.add_argument('--ursula-forward', action='store_true',
-                        help='The playbook to run')
+                        help='Forward SSH agent')
     parser.add_argument('--ursula-test', action='store_true',
                         help='Test syntax for playbook')
     parser.add_argument('--ursula-debug', action='store_true',


### PR DESCRIPTION
According to this: https://github.com/blueboxgroup/ursula-cli/blob/master/ursula_cli/shell.py#L366, all this does is forward the agent.

It's confusing.  Let's fix it.
