### PR TITLE
Update 2.0 support

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -103,7 +103,7 @@ def _run_ansible(inventory, playbook, user='root', module_path='./library',
     ]
 
     if sudo:
-        command.append("--sudo")
+        command.append("--become --become-method sudo")
     command += extra_args
 
     LOG.debug("Running command: %s with environment: %s",

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -30,7 +30,8 @@ import ansible
 
 
 LOG = logging.getLogger(__name__)
-ANSIBLE_VERSION = '2.0'
+ANSIBLE_VERSION_MIN = LooseVersion('2.0.2.0')
+ANSIBLE_VERSION_MAX = LooseVersion('3.0')
 
 
 def _initialize_logger(level=logging.DEBUG, logfile=None):
@@ -44,12 +45,14 @@ def _initialize_logger(level=logging.DEBUG, logfile=None):
 
 
 def _check_ansible_version():
-    version = ansible.__version__
-    if not LooseVersion(version) >= LooseVersion(ANSIBLE_VERSION):
-        raise Exception("You are using ansible-playbook '%s'. "
-                        "Current required version is: '%s'. You may install "
-                        "the correct version with 'pip install -U -r "
-                        "requirements.txt'" % (version, ANSIBLE_VERSION))
+    current_version = LooseVersion(ansible.__version__)
+    if not (ANSIBLE_VERSION_MIN >= current_version < ANSIBLE_VERSION_MAX):
+        raise Exception(
+            'You are using ansible-playbook "%s". The current required '
+            'version is between "%s" and "%s". You may install the correct '
+            'version with "pip install -U -r requirements.txt"'
+            % (current_version, ANSIBLE_VERSION_MIN, ANSIBLE_VERSION_MAX)
+        )
 
 
 def _append_envvar(key, value):

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -15,18 +15,19 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 
-import ansible
-import argparse
-import logging
 import os
-import shutil
-import socket
-import subprocess
 import sys
 import time
-import yaml
-
+import shutil
+import socket
+import logging
+import argparse
+import subprocess
 from distutils.version import LooseVersion
+
+import yaml
+import ansible
+
 
 LOG = logging.getLogger(__name__)
 ANSIBLE_VERSION = '2.0'


### PR DESCRIPTION
- Re-orgs imports more pep8-y (https://www.python.org/dev/peps/pep-0008/#imports)
- Pins package between GTE 2.0.2.0 and LT 3.0
- Adds become commands
