### PR TITLE
Handle NoSectionError in log setup

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -23,7 +23,7 @@ import socket
 import logging
 import argparse
 import subprocess
-from ConfigParser import ConfigParser, NoOptionError
+from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 import yaml
 
@@ -36,7 +36,7 @@ def init_logfile():
     config.read('ansible.cfg')
     try:
         cfg_log = config.get('defaults', 'log_path')
-    except NoOptionError:
+    except (NoOptionError, NoSectionError):
         cfg_log = None
 
     logfile = os.path.join(os.getcwd(), cfg_log or 'ursula.log')


### PR DESCRIPTION
NoSectionError is not handled by the logging setup which is particularly
likely when there is not an ansible.cfg file in the current working
directory.

Resolves #39
