### PR TITLE
Don't join log path to current directory

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -34,12 +34,17 @@ ANSIBLE_VERSION = '1.9.2-bbg'
 def init_logfile():
     config = ConfigParser()
     config.read('ansible.cfg')
+
     try:
         cfg_log = config.get('defaults', 'log_path')
     except (NoOptionError, NoSectionError):
         cfg_log = None
 
-    logfile = os.path.join(os.getcwd(), cfg_log or 'ursula.log')
+    if cfg_log:
+        logfile = os.path.expanduser(cfg_log)
+    else:
+        logfile = 'ursula.log'
+
     if not os.path.exists(logfile):
         with open(logfile, 'a'):
             os.utime(logfile, None)


### PR DESCRIPTION
By force joining the current directory to the log_path we prevent being
able to use absolute paths and ~user directories.

In fact there is no point forcing the join to the current working
directory at all and we can just use relative paths for this.

Resolves #41
