### PR TITLE
Allow downstream packages to consume Ansible 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+ansible
 pbr
 PyYAML
--e git://github.com/blueboxgroup/ansible.git@1.9.2-bbg#egg=ansible

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 
+import ansible
 import os
 import sys
 import time
@@ -27,8 +28,10 @@ from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 import yaml
 
+from distutils.version import LooseVersion
+
 LOG = logging.getLogger(__name__)
-ANSIBLE_VERSION = '1.9.2-bbg'
+MINIMUM_ANSIBLE_VERSION = '1.9'
 
 
 def init_logfile():
@@ -62,20 +65,12 @@ def _initialize_logger(level=logging.DEBUG, logfile=None):
 
 
 def _check_ansible_version():
-    process = subprocess.Popen(
-        ["ansible-playbook --version"], shell=True,
-        stdout=subprocess.PIPE)
-    output, _ = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        raise Exception("Error discovering ansible version")
-    version_output = output.split('\n')[0]
-    version = version_output.split(' ')[1]
-    if not version == ANSIBLE_VERSION:
+    version = ansible.__version__
+    if not LooseVersion(version) >= LooseVersion(MINIMUM_ANSIBLE_VERSION):
         raise Exception("You are using ansible-playbook '%s'. "
-                        "Current required version is: '%s'. You may install "
-                        "the correct version with 'pip install -U -r "
-                        "requirements.txt'" % (version, ANSIBLE_VERSION))
+                        "Current required version is at least: '%s'. You may "
+                        "install the correct version with 'pip install -U -r "
+                        "requirements.txt'" % (version, MINIMUM_ANSIBLE_VERSION))
 
 
 def _append_envvar(key, value):

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -121,7 +121,7 @@ def _run_ansible(inventory, playbook, user='root', module_path='./library',
     ]
 
     if sudo:
-        command.append("--sudo")
+        command.append("--become --become-method sudo")
     command += extra_args
 
     LOG.debug("Running command: %s with environment: %s",

--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -15,7 +15,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 
-import ansible
 import os
 import sys
 import time
@@ -24,11 +23,12 @@ import socket
 import logging
 import argparse
 import subprocess
+from distutils.version import LooseVersion
 from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 import yaml
+import ansible
 
-from distutils.version import LooseVersion
 
 LOG = logging.getLogger(__name__)
 MINIMUM_ANSIBLE_VERSION = '1.9'


### PR DESCRIPTION
Currently, ursula-cli had a hard requirement on version of Ansible. This change allows packages like ursula to set that requirement itself.
