### PR TITLE
Merge to ansible-2.0 branch: support customized heat stack name

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -182,7 +182,10 @@ def _run_heat(args, hot):
         'auth_url': os.environ['OS_AUTH_URL'],
     }
 
-    stack_name = os.path.basename(args.environment)
+    if args.heat_stack_name:
+        stack_name = args.heat_stack_name
+    else:
+        stack_name = os.path.basename(args.environment)
 
     STACK = {
         'stack_name': stack_name,
@@ -427,6 +430,9 @@ def main():
     parser.add_argument('--provisioner',
                         help='The external provisioner to use',
                         default=None, choices=["vagrant", "heat"])
+    parser.add_argument('--heat-stack-name',
+                        help='Name of the heat stack when heat provisioner is used',
+                        default=None)
     parser.add_argument('--vagrant', action='store_true',
                         help='Provision environment in vagrant')
     parser.add_argument('--ursula-sudo', action='store_true',


### PR DESCRIPTION
The attached commit in this PR has already been merged into master repo, and we also need it to be merged into ansible-2.0 branch to make it available during installation of ursula requirements.

Here is the description in the original pull request to master repo:
We'd like to have ursula-cli be able to support a customized heat stack name when heat provisioner is used. This will also enable the ability to run multiple Ursula heat provisioning in parallel against the same test Openstack cloud.
The code changes have been tested for both scenarios of with and without a customized heat stack name specified.
