### PR TITLE
Add heat requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 ansible
 pbr
 PyYAML
+python-keystoneclient
+python-heatclient


### PR DESCRIPTION
Since ursula-cli implements functionality with the Heat API, we should
simply include its requirements here.
