### PR TITLE
strip slash off end of environment arg

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -442,6 +442,8 @@ def run(args, extra_args):
     if not os.path.exists(args.environment):
         raise Exception("Environment '%s' does not exist" % args.environment)
 
+    args.environment = args.environment.rstrip('/').rstrip('\\')
+
     _set_envvar('URSULA_ENV', os.path.abspath(args.environment))
 
     inventory = os.path.join(args.environment, 'hosts')


### PR DESCRIPTION
When an env was passed in with a trailing slash the _vagrant_ssh_config method was failing when trying to do `os.path.basename(environment)`
https://github.com/blueboxgroup/ursula-cli/blob/master/ursula_cli/shell.py#L181

With a trailing slash the the result is empty so we were ending up with files named just `.ssh`.

