### PR TITLE
stack failure reason

### DIFF
--- a/ursula_cli/shell.py
+++ b/ursula_cli/shell.py
@@ -312,8 +312,8 @@ def _run_heat(args, hot):
 
     stack = heatclient.stacks.get(stack_name)
     if stack.status != 'COMPLETE':
-        raise Exception("stack %s returned an unexpected status (%s)" %
-                        (stack_name, stack.status))
+        raise Exception("stack %s returned an unexpected status (%s:%s)" %
+                        (stack_name, stack.status, stack.stack_status_reason))
 
     LOG.debug("Stack %sd!" % stack_action)
 


### PR DESCRIPTION
when stack creation, it did not report failure reason. In this change, failure reason is added to error message.

- previous stack failure message:
```
ERROR: stack CI-local-hb-master_stack returned an unexpected status (FAILED)
```

- new stack failure message:
```
ERROR: stack CI-local-hb-master_stack returned an unexpected status (FAILED):Resource CREATE failed: Forbidden: resources.controller-1: Quota exceeded for ram: Requested 8192, but
 already used 24576 of 26000 ram (HTTP 403) (Request-ID: req-03deee04-3c6e-4aa4-b62d-0deea2075cd6)```