### PR TITLE
add six to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible>=2.1.0.0,<3,<2.2
+six
 pbr
 PyYAML
 python-keystoneclient


### PR DESCRIPTION
With setuptools 36.0 ursula-cli pip install is failing with six import not found. This PR is adding six to requirements.txt